### PR TITLE
Add sphinx to the installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN sudo pacman --noconfirm --needed -S \
   nodejs \
   libnl \
   flex \
-  bison
+  bison \
+  python-requests \
+  python-pytz
 
-RUN sudo pip install pystache requests pytz
+RUN sudo pip install pystache

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN sudo pacman --noconfirm --needed -S \
   flex \
   bison \
   python-requests \
-  python-pytz
+  python-pytz \
+  python-sphinx \
+  python-sphinx_rtd_theme
 
 RUN sudo pip install pystache


### PR DESCRIPTION
We need `sphinx-build` to build python documentation
