### PR TITLE
Add python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN sudo pacman --noconfirm --needed -S \
   python-requests \
   python-pytz \
   python-sphinx \
-  python-sphinx_rtd_theme
+  python-sphinx_rtd_theme \
+  python2
 
 RUN sudo pip install pystache


### PR DESCRIPTION
Generally everything runs on Python 3 on Arch but to build some projects we need python2