### PR TITLE
Add Python Coverage support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN sudo vca-install-package \
   libnl \
   flex \
   bison \
+  python-coverage \
   python-requests \
   python-pytz \
   python-sphinx \


### PR DESCRIPTION
The tool chain will soon support creating a coverage report for the python files that it implements. Adding the `python-coverage` package allows for that to happen.