### PR TITLE
Split package install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,34 +18,75 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 # Install the packages needed for the VCA tool chain
+RUN sudo vca-install-package  \
+  gcc
+
 RUN sudo vca-install-package \
-  alsa-utils \
+  clang \
+  clang-tools-extra \
+  llvm
+
+RUN sudo vca-install-package \
   autoconf \
   bc \
   bison \
-  boost \
   check \
-  clang \
-  clang-tools-extra \
-  cppcheck \
   cppunit \
   dialog \
+  flex \
+  nasm \
+  openssh \
+  patch \
+  pkg-config \
+  yasm
+
+RUN sudo vca-install-package \
+  gst-plugins-bad \
+  gst-plugins-base \
+  gst-plugins-good \
+  gst-plugins-ugly \
+  gst-libav \
+  gstreamer
+
+RUN sudo vca-install-package \
+  boost
+
+RUN sudo vca-install-package \
+  perl
+
+RUN sudo vca-install-package \
+  python2 \
+  python
+
+RUN sudo vca-install-package \
+  opencv
+
+RUN sudo vca-install-package \
+  qemu-arch-extra \
+  vde2
+
+RUN sudo vca-install-package \
+  python-coverage \
+  python-pip \
+  python-pytz \
+  python-requests \
+  python-sphinx \
+  python-sphinx_rtd_theme
+
+RUN sudo vca-install-package \
+  nodejs \
+  npm
+
+RUN sudo vca-install-package \
+  alsa-utils \
   doxygen \
   eigen \
   ffmpeg \
-  flex \
-  gcc \
   gnu-efi-libs \
   gperf \
   gptfdisk \
   graphviz \
   gsoap \
-  gst-libav \
-  gst-plugins-bad \
-  gst-plugins-base \
-  gst-plugins-good \
-  gst-plugins-ugly \
-  gstreamer \
   intltool \
   jansson \
   libcap-ng \
@@ -54,36 +95,14 @@ RUN sudo vca-install-package \
   libsigc++ \
   libsoup \
   libuv \
-  llvm \
-  nasm \
-  nodejs \
-  npm \
   nspr \
-  nspr \
-  opencv \
-  openssh \
   p7zip \
   pandoc \
-  patch \
-  perl \
-  pkg-config \
-  protobuf \
-  python-coverage \
-  python-pip \
-  python-pytz \
-  python-requests \
-  python-sphinx \
-  python-sphinx_rtd_theme \
-  python2 \
-  qemu-arch-extra \
-  qt4 \
   stress \
   systemd-sysvcompat \
   tinyxml \
   unrar \
-  valgrind \
-  vde2 \
-  yasm
+  valgrind
 
 RUN pip install --user pystache cpplint sseclient
 ENV PATH $PATH:/usr/bin/core_perl

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,71 +19,71 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 # Install the packages needed for the VCA tool chain
 RUN sudo vca-install-package \
-  python-pip \
-  gcc \
-  pkg-config \
-  openssh \
-  p7zip \
-  graphviz \
+  alsa-utils \
+  autoconf \
+  bc \
+  bison \
+  boost \
   check \
-  valgrind \
+  clang \
+  clang-tools-extra \
   cppcheck \
   cppunit \
-  protobuf \
-  boost \
-  jansson \
-  nspr \
-  pandoc \
-  qt4 \
+  dialog \
+  doxygen \
   eigen \
   ffmpeg \
-  nspr \
-  yasm \
-  opencv \
-  nasm \
+  flex \
+  gcc \
+  gnu-efi-libs \
+  gperf \
+  gptfdisk \
+  graphviz \
   gsoap \
-  tinyxml \
-  patch \
-  doxygen \
-  autoconf \
-  intltool \
-  libsoup \
-  gstreamer \
+  gst-libav \
+  gst-plugins-bad \
   gst-plugins-base \
   gst-plugins-good \
-  gst-plugins-bad \
   gst-plugins-ugly \
-  gst-libav \
-  libsigc++ \
-  systemd-sysvcompat \
-  dialog \
-  npm \
-  alsa-utils \
-  libuv \
+  gstreamer \
+  intltool \
+  jansson \
+  libcap-ng \
   libndp \
-  nodejs \
   libnl \
-  flex \
-  bison \
+  libsigc++ \
+  libsoup \
+  libuv \
+  llvm \
+  nasm \
+  nodejs \
+  npm \
+  nspr \
+  nspr \
+  opencv \
+  openssh \
+  p7zip \
+  pandoc \
+  patch \
+  perl \
+  pkg-config \
+  protobuf \
   python-coverage \
-  python-requests \
+  python-pip \
   python-pytz \
+  python-requests \
   python-sphinx \
   python-sphinx_rtd_theme \
   python2 \
-  unrar \
-  llvm \
-  clang \
-  clang-tools-extra \
-  perl \
-  vde2 \
   qemu-arch-extra \
-  libcap-ng \
-  bc \
-  gperf \
-  gnu-efi-libs \
-  gptfdisk \
-  stress
+  qt4 \
+  stress \
+  systemd-sysvcompat \
+  tinyxml \
+  unrar \
+  valgrind \
+  vde2 \
+  yasm
 
 RUN pip install --user pystache cpplint sseclient
 ENV PATH $PATH:/usr/bin/core_perl


### PR DESCRIPTION
Having all the packages install in the same layer leads to a large
layer that changes when *any* of the packages change version.

This patch attempts to split packages into groups that are:
  * Large packages
  * Part of the same project so version number will change together

There is more possibility to break down the groups more, we ideally
want to keep the layers less than 100MiB each